### PR TITLE
Make requirements compatible with CAPEv2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ setup(
     license="GNU GPLv3",
     url="http://eternal-todo.com",
     install_requires=[
-        "jsbeautifier==1.6.2",
-        "colorama==0.3.7",
+        "jsbeautifier>=1.6.2",
+        "colorama>=0.3.7",
         "future>=0.16.0",
         "Pillow",
         "pythonaes==1.0",


### PR DESCRIPTION
CAPEv2 requires https://github.com/fireeye/capa which requires halo which requires colorama>=0.3.9. Therefore I'm loosening the current colorama==0.3.7 requirement of peepdf to allow newer versions.

I'm also allowing newer versions of jsbeautifier because I see no point in requiring a 5 years old exact version.

The peepdf tests pass with the latest colorama and jsbeautifier versions.